### PR TITLE
aspect ratio updating

### DIFF
--- a/constrain/Classes/AspectRatio.swift
+++ b/constrain/Classes/AspectRatio.swift
@@ -38,10 +38,15 @@ public extension UIImage {
 public extension UIImageView {
     @discardableResult
     func constrainAspectToImage() -> Constraints {
-        guard let imageAspect = image?.aspectRatio else {
+        guard let image = image else {
             print("Image is not set.")
             return constrain
         }
-        return constrain.aspectRatio(imageAspect)
+        return constrainAspect(to: image)
+    }
+    
+    @discardableResult
+    func constrainAspect(to image: UIImage) -> Constraints {
+        return constrain.aspectRatio(image.aspectRatio)
     }
 }

--- a/constrain/Classes/AspectRatio.swift
+++ b/constrain/Classes/AspectRatio.swift
@@ -14,7 +14,7 @@ public extension Constraints {
     /// Checks that ratio is finite before applying (avoid divide by zero errors)
     /// Multiplier is not editable, so you need to replace this constraint to change the ratio, hence the optional parameter
     @discardableResult
-    func aspectRatio(_ ratio: CGFloat, by relationship: Relationship = .equal, priority: UILayoutPriority = .required, replacingExisting: Bool = false) -> Constraints {
+    func aspectRatio(_ ratio: CGFloat, by relationship: Relationship = .equal, priority: UILayoutPriority = .required, replacingExisting: Bool = true) -> Constraints {
         guard let view = view else {
             print("View fell out of memory.")
             return self

--- a/constrain/Classes/AspectRatio.swift
+++ b/constrain/Classes/AspectRatio.swift
@@ -31,7 +31,15 @@ public extension UIImage {
     /// may return NaN, but I decided this is preferable to Nil
     /// constrain.aspectRatio() checks for `.isFinite` before setting to avoid crash
     var aspectRatio: CGFloat {
-        return size.width/size.height
+        return size.aspectRatio
+    }
+}
+
+public extension CGSize {
+    /// may return NaN, but I decided this is preferable to Nil
+    /// constrain.aspectRatio() checks for `.isFinite` before setting to avoid crash
+    var aspectRatio: CGFloat {
+        return width/height
     }
 }
 

--- a/constrain/Classes/AspectRatio.swift
+++ b/constrain/Classes/AspectRatio.swift
@@ -20,7 +20,7 @@ public extension Constraints {
             return self
         }
         if replacingExisting {
-            removeConstraintWithIdentifier(.aspectRatio)
+            removeConstraintsWithIdentifier(.aspectRatio)
         }
         return applyDimensionMultiplier(dimension1: view.widthAnchor, dimension2: view.heightAnchor, identifier: ConstraintIdentifier.aspectRatio, constant: 0, multiplier: ratio, relationship: relationship, priority: priority)
     }

--- a/constrain/Classes/AspectRatio.swift
+++ b/constrain/Classes/AspectRatio.swift
@@ -12,13 +12,15 @@ public extension Constraints {
     /// Apply an aspect ratio constraint to a view
     /// Ratio is expressed as width/height
     /// Checks that ratio is finite before applying (avoid divide by zero errors)
-    /// Multiplier is not editable, so you need to replace this constraint to change the ratio
-    /// TODO: replacement helper function?
+    /// Multiplier is not editable, so you need to replace this constraint to change the ratio, hence the optional parameter
     @discardableResult
-    func aspectRatio(_ ratio: CGFloat, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
+    func aspectRatio(_ ratio: CGFloat, by relationship: Relationship = .equal, priority: UILayoutPriority = .required, replacingExisting: Bool = false) -> Constraints {
         guard let view = view else {
             print("View fell out of memory.")
             return self
+        }
+        if replacingExisting {
+            removeConstraintWithIdentifier(.aspectRatio)
         }
         return applyDimensionMultiplier(dimension1: view.widthAnchor, dimension2: view.heightAnchor, identifier: ConstraintIdentifier.aspectRatio, constant: 0, multiplier: ratio, relationship: relationship, priority: priority)
     }

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -14,7 +14,7 @@ public typealias Relationship = NSLayoutConstraint.Relation
 public class Constraints {
     
     internal weak var view: UIView?
-    internal var viewName: String
+    private var viewName: String?
     internal var constraints: [ConstraintIdentifier: NSLayoutConstraint] = [:]
     internal var allConstraints: [NSLayoutConstraint] = []
     internal var isActive = true
@@ -23,7 +23,15 @@ public class Constraints {
     
     internal init(view: UIView, name: String? = nil) {
         self.view = view
-        self.viewName = name ?? String.init(describing: view.self)
+        self.viewName = name
+    }
+    
+    func identifier(for `case`: ConstraintIdentifier) -> String {
+        if let viewName = viewName {
+            return viewName + "." + `case`.rawValue
+        } else {
+            return `case`.rawValue
+        }
     }
     
 }
@@ -109,7 +117,7 @@ extension Constraints {
     fileprivate func finalizeConstraint(_ constraint: NSLayoutConstraint, _ identifier: ConstraintIdentifier) {
         view?.translatesAutoresizingMaskIntoConstraints = false
         constraint.isActive = isActive
-        constraint.identifier = viewName + identifier.rawValue
+        constraint.identifier = self.identifier(for: identifier)
         constraints[identifier] = constraint
         allConstraints.append(constraint)
         latestConstraint = constraint

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -42,7 +42,7 @@ extension Constraints {
         let allExistingConstraints = layoutConstraintsWithIdentifier(identifier)
         view?.removeConstraints(allExistingConstraints)
         constraints.removeValue(forKey: identifier)
-        allConstraints.removeAll { $0.identifier == identifier.rawValue}
+        allConstraints.removeAll { $0.identifier == identifier.rawValue }
         return self
     }
         

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -32,7 +32,7 @@ extension Constraints {
     
     /// uses all constraints on the view, not just the stored ones
     public func layoutConstraintsWithIdentifier(_ identifier: ConstraintIdentifier) -> [NSLayoutConstraint] {
-        view?.constraints.filter {
+        view?.allParticipatingConstraints.filter {
             $0.identifier ?? "" == identifier.rawValue
         } ?? []
     }
@@ -72,4 +72,20 @@ extension Constraints {
         return self
     }
     
+}
+
+public extension UIView {
+    var allParticipatingConstraints: [NSLayoutConstraint] {
+        let result = constraints
+        var superview = self.superview
+        while superview != nil {
+            for constraint in superview.constraints {
+                if (constraint.firstItem == self || constraint.secondItem == self) {
+                    result.append(constraint)
+                }
+            }
+            superview = superview.superview
+        }
+        return result
+    }
 }

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -75,16 +75,20 @@ extension Constraints {
 }
 
 public extension UIView {
+    /// UIView.constraints only returns constraints *owned* by that view.
+    /// adapted from https://stackoverflow.com/questions/24418884/remove-all-constraints-affecting-a-uiview
     var allParticipatingConstraints: [NSLayoutConstraint] {
-        let result = self.constraints
-        var superview = self.superview
-        while superview != nil {
+        var result = self.constraints
+        var _superview = self.superview
+        while let superview = _superview {
             for constraint in superview.constraints {
-                if (constraint.firstItem == self || constraint.secondItem == self) {
+                if let first = constraint.firstItem as? UIView, first == self {
+                    result.append(constraint)
+                } else if let second = constraint.secondItem as? UIView, second == self {
                     result.append(constraint)
                 }
             }
-            superview = superview.superview
+            _superview = superview.superview
         }
         return result
     }

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -18,7 +18,7 @@ public enum ConstraintIdentifier: String {
     case centerY = "centerY"
     case aspectRatio = "aspectRatio"
 
-    // Not actuallyconstraints:
+    // Not actually constraints:
     case cornerRadius = "cornerRadius"
     case size = "size" // combines width and height
 }

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -6,21 +6,21 @@
 //
 
 public enum ConstraintIdentifier: String {
-    case top = ".top"
-    case leading = ".leading"
-    case trailing = ".trailing"
-    case bottom = ".bottom"
-    case topSafe = ".topSafe"
-    case bottomSafe = ".bottomSafe"
-    case height = ".height"
-    case width = ".width"
-    case centerX = ".centerX"
-    case centerY = ".centerY"
-    case aspectRatio = ".aspectRatio"
+    case top = "top"
+    case leading = "leading"
+    case trailing = "trailing"
+    case bottom = "bottom"
+    case topSafe = "topSafe"
+    case bottomSafe = "bottomSafe"
+    case height = "height"
+    case width = "width"
+    case centerX = "centerX"
+    case centerY = "centerY"
+    case aspectRatio = "aspectRatio"
 
-    // Not actually constraints:
-    case cornerRadius = ".cornerRadius"
-    case size = ".size" // size combines .width and .height
+    // Not actuallyconstraints:
+    case cornerRadius = "cornerRadius"
+    case size = "size" // combines width and height
 }
 
 extension Constraints {
@@ -33,7 +33,7 @@ extension Constraints {
     /// uses all constraints on the view, not just the stored ones
     public func layoutConstraintsWithIdentifier(_ identifier: ConstraintIdentifier) -> [NSLayoutConstraint] {
         view?.allParticipatingConstraints.filter {
-            $0.identifier ?? "" == identifier.rawValue
+            $0.identifier ?? "" == self.identifier(for: identifier)
         } ?? []
     }
     

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -30,14 +30,19 @@ extension Constraints {
         return constraints[identifier]
     }
     
+    /// uses all constraints on the view, not just the stored ones
+    public func layoutConstraintsWithIdentifier(_ identifier: ConstraintIdentifier) -> [NSLayoutConstraint] {
+        view?.constraints.filter {
+            $0.identifier ?? "" == identifier.rawValue
+        } ?? []
+    }
+    
     @discardableResult
-    public func removeConstraintWithIdentifier(_ identifier: ConstraintIdentifier) -> Self {
-        guard let constraint = layoutConstraintWithIdentifier(identifier) else { return self }
-        view?.removeConstraint(constraint)
-        constraints[identifier] = nil
-        if let index = allConstraints.firstIndex(of: constraint) {
-            allConstraints.remove(at: index)
-        }
+    public func removeConstraintsWithIdentifier(_ identifier: ConstraintIdentifier) -> Self {
+        let allExistingConstraints = layoutConstraintsWithIdentifier(identifier)
+        view?.removeConstraints(allExistingConstraints)
+        constraints.removeValue(forKey: identifier)
+        allConstraints.removeAll { $0.identifier == identifier.rawValue}
         return self
     }
         

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -76,7 +76,7 @@ extension Constraints {
 
 public extension UIView {
     var allParticipatingConstraints: [NSLayoutConstraint] {
-        let result = constraints
+        let result = self.constraints
         var superview = self.superview
         while superview != nil {
             for constraint in superview.constraints {

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -30,6 +30,17 @@ extension Constraints {
         return constraints[identifier]
     }
     
+    @discardableResult
+    public func removeConstraintWithIdentifier(_ identifier: ConstraintIdentifier) -> Self {
+        guard let constraint = layoutConstraintWithIdentifier(identifier) else { return self }
+        view?.removeConstraint(constraint)
+        constraints[identifier] = nil
+        if let index = allConstraints.firstIndex(of: constraint) {
+            allConstraints.remove(at: index)
+        }
+        return self
+    }
+        
     /// When storing a reference to a Constraints instance this method allows to set the constant of a respective constraint.
     public func setConstant(_ constant: CGFloat, forIdentifier identifier: ConstraintIdentifier) {
         layoutConstraintWithIdentifier(identifier)?.constant = constant


### PR DESCRIPTION
 - new function removeConstraintWithIdentifier
 - new optional parameter on `aspectRatio` func `replacingExisting`

more recent:
 - default `replacingExisting` to true
 - `removeConstraintsWithIdentifier` searches all existing constraints, not just this instance of the `Constraints` helper
 - `allParticipatingConstraints` extension to aid with this
 - `UIImageView.setImage(withCacheURL:)` now has `enforceAspect:` Bool param to aid in setting aspect after loading
 - Don't add `viewName` to the constraint identifier unless it's been manually set (more deterministic)

PR that will use this, for context https://github.com/vidahealth/via_ios/pull/5820