### PR TITLE
Make height/width inputs safer

### DIFF
--- a/constrain/Classes/BaseTypes.swift
+++ b/constrain/Classes/BaseTypes.swift
@@ -91,8 +91,9 @@ public extension Constraints {
 // Height and width stuff
 public extension Constraints {
     /// Set the height constraint to a constant
+    // Can't have the constant param be anonymous or have a default or it would overload the anchor equivalent
     @discardableResult
-    func height(_ constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
+    func height(to constant: CGFloat, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view else {
             print("View fell out of memory.")
             return self
@@ -111,8 +112,9 @@ public extension Constraints {
     }
     
     /// Set the width constraint to a constant
+    // Can't have the constant param be anonymous or have a default or it would overload the anchor equivalent
     @discardableResult
-    func width(_ constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
+    func width(to constant: CGFloat, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view else {
             print("View fell out of memory.")
             return self
@@ -183,8 +185,8 @@ public extension Constraints {
     @discardableResult
     func size(width: CGFloat, height: CGFloat, by relationship: Relationship = .equal) -> Constraints {
         return self
-            .width(width, by: relationship)
-            .height(height, by: relationship)
+            .width(to: width, by: relationship)
+            .height(to: height, by: relationship)
     }
     
     /// Constraint the height and width of one view to those of another

--- a/constrain/Classes/BaseTypes.swift
+++ b/constrain/Classes/BaseTypes.swift
@@ -102,13 +102,12 @@ public extension Constraints {
     
     /// Constrains the height of one view to the height of another
     @discardableResult
-    func height(to anchor: NSLayoutDimension? = nil, constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
-        guard let view = view,
-            let anchor2 = anchor ?? view.superview?.heightAnchor else {
-                print("Trying to create height constraint without reference anchor")
-                return self
+    func height(to anchor: NSLayoutDimension, constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
+        guard let view = view else {
+            print("View fell out of memory.")
+            return self
         }
-        return applyAnchorConstraint(anchor1: view.heightAnchor, anchor2: anchor2, identifier: .height, constant: constant, relationship: relationship, priority: priority)
+        return applyAnchorConstraint(anchor1: view.heightAnchor, anchor2: anchor, identifier: .height, constant: constant, relationship: relationship, priority: priority)
     }
     
     /// Set the width constraint to a constant
@@ -123,13 +122,12 @@ public extension Constraints {
     
     /// Constrains the width of one view to the width of another
     @discardableResult
-    func width(to anchor: NSLayoutDimension? = nil, constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
-        guard let view = view,
-            let anchor2 = anchor ?? view.superview?.widthAnchor else {
-                print("Trying to create width constraint without reference anchor")
-                return self
+    func width(to anchor: NSLayoutDimension, constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
+        guard let view = view else {
+            print("View fell out of memory.")
+            return self
         }
-        return applyAnchorConstraint(anchor1: view.widthAnchor, anchor2: anchor2, identifier: .width, constant: constant, relationship: relationship, priority: priority)
+        return applyAnchorConstraint(anchor1: view.widthAnchor, anchor2: anchor, identifier: .width, constant: constant, relationship: relationship, priority: priority)
     }
     
 }
@@ -191,10 +189,10 @@ public extension Constraints {
     
     /// Constraint the height and width of one view to those of another
     @discardableResult
-    func size(to view: UIView? = nil, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
+    func size(to view: UIView, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         return self
-            .height(to: view?.heightAnchor, by: relationship, priority: priority)
-            .width(to: view?.widthAnchor, by: relationship, priority: priority)
+            .height(to: view.heightAnchor, by: relationship, priority: priority)
+            .width(to: view.widthAnchor, by: relationship, priority: priority)
     }
     
 }


### PR DESCRIPTION
Anchor versions: constraining one view's dimension to another view's dimension
Constant version: constrain a view's dimension to a constant

 - reverts 9c055fb598f520a0aaa1b7ba6fdb039997b7e429: inferring superview on the anchor versions was a huge mistake because it allows the anchor version of width/height to overload the constant version of width/height. First noticed when Vir was onboarding and it was calling the wrong one unexpectedly.
 - de-anonymizes constant versions' Float input params for clarity
 - remove default values from constant versions' Float input params (why would zero be the default??)

These are breaking changes, but worth it.