### PR TITLE
deprecate and migrate

### DIFF
--- a/constrain/Classes/Extensions.swift
+++ b/constrain/Classes/Extensions.swift
@@ -9,9 +9,9 @@ import UIKit
 
 public extension UIViewController {
     @discardableResult
+    @available(*, deprecated, renamed: "UIViewController.constrainChild(_:)", message: "Can't add VC without parent/child relationship")
     func constrainSubview(_ viewController: UIViewController) -> Constraints {
-        view.addSubview(viewController.view)
-        return viewController.view.constrain
+        constrainChild(viewController)
     }
     
     @discardableResult
@@ -41,7 +41,7 @@ public extension UIViewController {
 }
 
 public extension UIView {
-    @discardableResult
+    @available(*, deprecated, message: "Can't add VC without parent/child relationship, use constrainChild(_: to:) from the parent VC")
     func constrainSubview(_ viewController: UIViewController) -> Constraints {
         addSubview(viewController.view)
         return viewController.view.constrain

--- a/constrain/Classes/Extensions.swift
+++ b/constrain/Classes/Extensions.swift
@@ -41,6 +41,7 @@ public extension UIViewController {
 }
 
 public extension UIView {
+    @discardableResult
     @available(*, deprecated, message: "Can't add VC without parent/child relationship, use constrainChild(_: to:) from the parent VC")
     func constrainSubview(_ viewController: UIViewController) -> Constraints {
         addSubview(viewController.view)


### PR DESCRIPTION
VCs should not be added to the view hierarchy without giving them a parent, otherwise the VC can fall out of scope and break the layout and lifecycle methods, among other things