### PR TITLE
Pin to keyboard

### DIFF
--- a/constrain/Classes/BaseTypes.swift
+++ b/constrain/Classes/BaseTypes.swift
@@ -15,9 +15,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = anchor ?? view.superview?.topAnchor
-            else {
-                print("Attempting to create top constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create top constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.topAnchor, anchor2: anchor, identifier: .top, constant: constant, relationship: relationship, priority: priority)
     }
@@ -28,9 +28,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = anchor ?? view.superview?.bottomAnchor
-            else {
-                print("Attempting to create bottom constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create bottom constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.bottomAnchor, anchor2: anchor, identifier: .bottom, constant: -constant, relationship: relationship, priority: priority)
     }
@@ -41,9 +41,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = anchor ?? view.superview?.leadingAnchor
-            else {
-                print("Attempting to create leading constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create leading constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.leadingAnchor, anchor2: anchor, identifier: .leading, constant: constant, relationship: relationship, priority: priority)
     }
@@ -54,9 +54,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = anchor ?? view.superview?.trailingAnchor
-            else {
-                print("Attempting to create trailing constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create trailing constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.trailingAnchor, anchor2: anchor, identifier: .trailing, constant: -constant, relationship: relationship, priority: priority)
     }
@@ -67,9 +67,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = anchor ?? view.superview?.centerXAnchor
-            else {
-                print("Attempting to create centerX constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create centerX constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.centerXAnchor, anchor2: anchor, identifier: .centerX, constant: constant, relationship: relationship, priority: priority)
     }
@@ -80,9 +80,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = anchor ?? view.superview?.centerYAnchor
-            else {
-                print("Attempting to create centerY constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create centerY constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.centerYAnchor, anchor2: anchor, identifier: .centerY, constant: constant, relationship: relationship, priority: priority)
     }
@@ -104,9 +104,9 @@ public extension Constraints {
     @discardableResult
     func height(to anchor: NSLayoutDimension? = nil, constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view,
-            let anchor2 = anchor ?? view.superview?.heightAnchor else {
-                print("Trying to create height constraint without reference anchor")
-                return self
+              let anchor2 = anchor ?? view.superview?.heightAnchor else {
+            print("Trying to create height constraint without reference anchor")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.heightAnchor, anchor2: anchor2, identifier: .height, constant: constant, relationship: relationship, priority: priority)
     }
@@ -125,9 +125,9 @@ public extension Constraints {
     @discardableResult
     func width(to anchor: NSLayoutDimension? = nil, constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view,
-            let anchor2 = anchor ?? view.superview?.widthAnchor else {
-                print("Trying to create width constraint without reference anchor")
-                return self
+              let anchor2 = anchor ?? view.superview?.widthAnchor else {
+            print("Trying to create width constraint without reference anchor")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.widthAnchor, anchor2: anchor2, identifier: .width, constant: constant, relationship: relationship, priority: priority)
     }

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -17,7 +17,7 @@ public enum ConstraintIdentifier: String {
     case centerX = "centerX"
     case centerY = "centerY"
     case aspectRatio = "aspectRatio"
-
+    
     // Not actually constraints:
     case cornerRadius = "cornerRadius"
     case size = "size" // combines width and height
@@ -45,12 +45,12 @@ extension Constraints {
         allConstraints.removeAll { $0.identifier == identifier.rawValue }
         return self
     }
-        
+    
     /// When storing a reference to a Constraints instance this method allows to set the constant of a respective constraint.
     public func setConstant(_ constant: CGFloat, forIdentifier identifier: ConstraintIdentifier) {
         layoutConstraintWithIdentifier(identifier)?.constant = constant
     }
-
+    
     @discardableResult
     public func update(_ identifier: ConstraintIdentifier, to constant: CGFloat) -> Self {
         // constrain will start to support setting and updating of view propperties that are not actually NSLayoutConstraints. We have to treat them slightly differently.
@@ -65,7 +65,7 @@ extension Constraints {
         }
         return self
     }
-
+    
     @discardableResult
     public func cornerRadius(_ value: CGFloat) -> Self {
         view?.layer.cornerRadius = value

--- a/constrain/Classes/SafeArea.swift
+++ b/constrain/Classes/SafeArea.swift
@@ -48,10 +48,10 @@ public extension Constraints {
     @discardableResult
     func topSafe(_ constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view,
-            let anchor = view.superview?.topAnchorSafe
-            else {
-                print("Attempting to create top constraint without a reference anchor.")
-                return self
+              let anchor = view.superview?.topAnchorSafe
+        else {
+            print("Attempting to create top constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.topAnchor, anchor2: anchor, identifier: .top, constant: constant, relationship: relationship, priority: priority)
     }
@@ -60,10 +60,10 @@ public extension Constraints {
     @discardableResult
     func bottomSafe(_ constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view,
-            let anchor = view.superview?.bottomAnchorSafe
-            else {
-                print("Attempting to create bottom constraint without a reference anchor.")
-                return self
+              let anchor = view.superview?.bottomAnchorSafe
+        else {
+            print("Attempting to create bottom constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.bottomAnchor, anchor2: anchor, identifier: .bottom, constant: -constant, relationship: relationship, priority: priority)
     }
@@ -119,9 +119,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = view2?.centerXAnchorSafe ?? view.superview?.centerXAnchor
-            else {
-                print("Attempting to create centerX constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create centerX constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.centerXAnchor, anchor2: anchor, identifier: .centerX, constant: constant, relationship: relationship, priority: priority)
     }
@@ -132,9 +132,9 @@ public extension Constraints {
         guard
             let view = view,
             let anchor = view2?.centerYAnchorSafe ?? view.superview?.centerYAnchorSafe
-            else {
-                print("Attempting to create centerY constraint without a reference anchor.")
-                return self
+        else {
+            print("Attempting to create centerY constraint without a reference anchor.")
+            return self
         }
         return applyAnchorConstraint(anchor1: view.centerYAnchor, anchor2: anchor, identifier: .centerY, constant: constant, relationship: relationship, priority: priority)
     }

--- a/constrain/Classes/SafeArea.swift
+++ b/constrain/Classes/SafeArea.swift
@@ -68,6 +68,17 @@ public extension Constraints {
         return applyAnchorConstraint(anchor1: view.bottomAnchor, anchor2: anchor, identifier: .bottom, constant: -constant, relationship: relationship, priority: priority)
     }
     
+    @discardableResult @available(iOS 15.0, *)
+    func pinToKeyboard(padding: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
+        guard let view = view,
+              let anchor = view.superview?.keyboardLayoutGuide.topAnchor
+        else {
+            print("Attempting to create keyboard constraint without a reference anchor.")
+            return self
+        }
+        return applyAnchorConstraint(anchor1: view.bottomAnchor, anchor2: anchor, identifier: .bottom, constant: -padding, relationship: relationship, priority: priority)
+    }
+    
     /// iOS 11 introduced safe area layout constraints.
     /// When filling the native UIViewController view, consider a method that aligns to the safe area.
     @discardableResult


### PR DESCRIPTION
 - make use of new [keyboardLayoutGuide](https://developer.apple.com/documentation/uikit/keyboards_and_input/adjusting_your_layout_with_keyboard_layout_guide) to keep CTA buttons above the keyboard (paired with https://github.com/vidahealth/via_ios/pull/7718)
 - update some indents for new rules

Examples
Acct verification | Password change
--- | ---
![Simulator Screen Shot - iPhone 14 - 2023-05-31 at 15 45 47](https://github.com/gsbernstein/constrain/assets/6655924/ecb1b8f7-1b00-4c7f-9a87-efb51175679e)|![Simulator Screen Shot - iPhone 14 - 2023-05-31 at 15 45 51](https://github.com/gsbernstein/constrain/assets/6655924/99d19341-0d4a-4d75-a5fe-5b2b47fced91)


https://github.com/gsbernstein/constrain/assets/6655924/33f54170-4e99-4a6f-8c95-da8b78449a59